### PR TITLE
Add `evaluation-summary` as an output type

### DIFF
--- a/docmaps-context.jsonld
+++ b/docmaps-context.jsonld
@@ -156,6 +156,7 @@
             "@type": "@id"
         },
         "reply": "fabio:Reply",
+        "evaluation-summary": "fabio:ExecutiveSummary",
         "comment": "fabio:Comment",
         "editorial": "fabio:Editorial"
     }


### PR DESCRIPTION
eLife is working on a project where they want to ingest review content about an article from a Docmap.
One aspect that is important to them is being able to distinguish output types; one of the types of relevance to them is an evaluation summary which currently is not available in this context with a standard alias.

Here is an example article that exhibits this type of review content:
https://sciety.org/articles/activity/10.1101/2021.06.02.446694

We have started hardcoding a Docmap version of this at:
https://staging.sciety.org/docmaps/v1/evaluations-by/elife/10.1101/2021.06.02.446694.docmap.json

Is the proposed change the correct approach?